### PR TITLE
don't swallow hunk at end of file

### DIFF
--- a/colordiff.py
+++ b/colordiff.py
@@ -102,5 +102,6 @@ class ColorDiff:
             else:
                 self.flushAll()
                 sys.stdout.write(line)
+        self.flushAll()
 
 ColorDiff().run()


### PR DESCRIPTION
trivial repro:

$ diff -u <(echo a) <(echo b)
--- /dev/fd/63  2012-07-12 18:28:10.759153029 +0300
+++ /dev/fd/62  2012-07-12 18:28:10.759153029 +0300
@@ -1 +1 @@
-a
+b

$ diff -u <(echo a) <(echo b) | colordiff.py 
--- /dev/fd/63  2012-07-12 18:28:36.307995376 +0300
+++ /dev/fd/62  2012-07-12 18:28:36.307995376 +0300
@@ -1 +1 @@
